### PR TITLE
WIP - added suggestion for a common interface

### DIFF
--- a/include/ethercat_sdk_master/EthercatActuatorDevice.h
+++ b/include/ethercat_sdk_master/EthercatActuatorDevice.h
@@ -44,7 +44,7 @@ public:
     class EthercatActuatorDeviceCommand
     {
     public:
-        EthercatActuatorDeviceControlMode mode = EthercatActuatorDeviceControlMode::None;
+        uint32_t mode = static_cast<uint32_t>(EthercatActuatorDeviceControlMode::None);
         double currentQdes = 0; //A
         double motorVelocityDes = 0; //rad/s
         double motorPositionDes = 0; //rad

--- a/include/ethercat_sdk_master/EthercatActuatorDevice.h
+++ b/include/ethercat_sdk_master/EthercatActuatorDevice.h
@@ -1,0 +1,58 @@
+/*
+ ** Copyright 2020 Robotic Systems Lab - ETH Zurich:
+ ** Lennart Nachtigall, Jonas Junger
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ **
+ ** 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ **
+ ** 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ **
+ ** 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "EthercatDevice.hpp"
+
+namespace ecat_master {
+class EthercatActuatorDevice: public EthercatDevice
+{
+
+public:
+    typedef std::shared_ptr<EthercatActuatorDevice> SharedPtr;
+
+    class EthercatActuatorDeviceReading
+    {
+    public:
+        double currentQ = 0;        //A
+        double motorVelocity = 0;   //rad/s
+        double motorPosition = 0;   //rad
+        double temperature = 0;     //°C
+        std::chrono::system_clock::time_point timeStamp; //Time
+    };
+
+    enum class EthercatActuatorDeviceControlMode
+    {
+        None = 0,
+        Current = 1,
+        Velocity = 2,
+        Position = 3,
+    };
+
+    class EthercatActuatorDeviceCommand
+    {
+    public:
+        EthercatActuatorDeviceControlMode mode = EthercatActuatorDeviceControlMode::None;
+        double currentQdes = 0; //A
+        double motorVelocityDes = 0; //rad/s
+        double motorPositionDes = 0; //rad
+    };
+
+    virtual EthercatActuatorDeviceReading getLatestReading() const = 0;
+    virtual bool setCommand(const EthercatActuatorDeviceCommand& command) = 0;
+
+
+};
+}

--- a/include/ethercat_sdk_master/EthercatActuatorDevice.h
+++ b/include/ethercat_sdk_master/EthercatActuatorDevice.h
@@ -50,9 +50,23 @@ public:
         double motorPositionDes = 0; //rad
     };
 
-    virtual EthercatActuatorDeviceReading getLatestReading() const = 0;
+    /**
+     * @brief getLatestReading
+     * @return The reading from the last update step
+     */
+    virtual std::shared_ptr<EthercatActuatorDeviceReading> getLatestReading() const = 0;
+    /**
+     * @brief setCommand - The command to be sent in the next update step
+     * @param command
+     * @return true in case of success
+     */
     virtual bool setCommand(const EthercatActuatorDeviceCommand& command) = 0;
 
+    /**
+     * @brief getAvailableReadingFields
+     * @return vector of pairs that contain the name + a getter function in order to access a certain field in
+     */
+    virtual std::vector<std::pair<std::string, std::function<double(void)>>> getAvailableReadingFields(std::shared_ptr<EthercatActuatorDeviceReading> _reading) = 0;
 
 };
 }

--- a/include/ethercat_sdk_master/EthercatActuatorDevice.h
+++ b/include/ethercat_sdk_master/EthercatActuatorDevice.h
@@ -60,13 +60,14 @@ public:
      * @param command
      * @return true in case of success
      */
-    virtual bool setCommand(const EthercatActuatorDeviceCommand& command) = 0;
+    virtual bool setCommand(const std::shared_ptr<EthercatActuatorDeviceCommand>& command) = 0;
 
     /**
      * @brief getAvailableReadingFields
      * @return vector of pairs that contain the name + a getter function in order to access a certain field in
      */
     virtual std::vector<std::pair<std::string, std::function<double(void)>>> getAvailableReadingFields(std::shared_ptr<EthercatActuatorDeviceReading> _reading) = 0;
+    virtual std::vector<std::pair<std::string, std::function<void(double)>>> getAvailableCommandFields(std::shared_ptr<EthercatActuatorDeviceCommand> _command) = 0;
 
 };
 }


### PR DESCRIPTION
This PR adds a suggestion for a common interface for actuators. 
The idea is to define a common subset of commands every actuator device should implement.

This would allow in the `ethercat_device_configurator` to obtain a pointer to an `EthercatActuatorDevice` and would allow some applications to easily change actuators (e.g. on the testbench)

Edit: I added a method `getAvailableReadingFields` that provides a meta interface to extended readings. The idea is that the device that implements this interface generates methods that allow  accessing extending fields by name. 
E.g. The Elmo inherits from the EthercatActuatorDeviceReading and adds a JointVelocity field. 
I would suggest adding similar methods for the Commands + Modes. 