### PR TITLE
Assign a single core (core 1) for the ethercat master thread

### DIFF
--- a/include/ethercat_sdk_master/EthercatMaster.hpp
+++ b/include/ethercat_sdk_master/EthercatMaster.hpp
@@ -133,7 +133,7 @@ public:
    * from core to core. Default -1: Dont attach to any core. Has to be < than number of avaible cores
    * @return True if successful
    */
-  bool setRealtimePriority(int priority = 99, int cpu_core = -1);
+  bool setRealtimePriority(int priority = 99, int cpu_core = -1) const;
 
   /*!
    * Resets the update rate scheduler (heartbeat reset).

--- a/include/ethercat_sdk_master/EthercatMaster.hpp
+++ b/include/ethercat_sdk_master/EthercatMaster.hpp
@@ -129,9 +129,11 @@ public:
    * scheduling parameters (/etc/security/limits.conf, man limits.conf)
    * @param[in] priority Prioirity of the calling thread.
    * Default: 99, Range on most systems: 1 - 99
+   * @param[in] cpu_core. Allows locking the thread to a certain cpu core to avoid the thread hopping
+   * from core to core. Default -1: Dont attach to any core. Has to be < than number of avaible cores
    * @return True if successful
    */
-  bool setRealtimePriority(int priority = 99);
+  bool setRealtimePriority(int priority = 99, int cpu_core = -1);
 
   /*!
    * Resets the update rate scheduler (heartbeat reset).

--- a/src/ethercat_sdk_master/EthercatMaster.cpp
+++ b/src/ethercat_sdk_master/EthercatMaster.cpp
@@ -144,7 +144,7 @@ bool EthercatMaster::setRealtimePriority(int priority, int cpu_core) const{
   if(cpu_core > 0 )
   {
       //check if the core is < than the number of available cpus
-      if(cpu_core > number_of_cpus)
+      if(cpu_core >= number_of_cpus)
       {
           MELO_ERROR_STREAM("[ethercat_sdk_master:EthercatMaster::setRealtimePriority]" <<
                             "Tried to attach thread to core: " << cpu_core << " even though we only have: " << number_of_cpus  << " core!");

--- a/src/ethercat_sdk_master/EthercatMaster.cpp
+++ b/src/ethercat_sdk_master/EthercatMaster.cpp
@@ -118,7 +118,7 @@ bool EthercatMaster::deviceExists(const std::string& name){
   return false;
 }
 
-bool EthercatMaster::setRealtimePriority(int priority, int cpu_core){
+bool EthercatMaster::setRealtimePriority(int priority, int cpu_core) const{
   bool success = true;
   //Handle to our thread
   pthread_t thread = pthread_self();


### PR DESCRIPTION
This PR assigns the ethercat master thread to the CPU Core 1 (if possible)
The hope with this fix is to get a more stable update rate (hopefully less issues with the elmo on the testbench)