### PR TITLE
Feature/ros2control

### DIFF
--- a/ethercat_sdk_master/CMakeLists.txt
+++ b/ethercat_sdk_master/CMakeLists.txt
@@ -47,12 +47,13 @@ target_include_directories(${PROJECT_NAME}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
+target_compile_options(${PROJECT_NAME} PUBLIC -fPIC)
+
 ament_target_dependencies(
     ${PROJECT_NAME} ${PACKAGE_DEPENDENCIES})
 ament_export_dependencies(${PACKAGE_DEPENDENCIES})
 
 ament_export_targets(${PROJECT_NAME}Target) #Does Threads needs to be exportet?
-ament_export_dependencies(${PACKAGE_DEPENDENCIES})
 
 #############
 ## Install ##

--- a/ethercat_sdk_master/CMakeLists.txt
+++ b/ethercat_sdk_master/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(Threads REQUIRED)
 add_library(${PROJECT_NAME}
   src/${PROJECT_NAME}/EthercatMaster.cpp
   src/${PROJECT_NAME}/EthercatDevice.cpp
+  src/${PROJECT_NAME}/EthercatMasterSingleton.cpp
 )
 
 target_include_directories(${PROJECT_NAME}

--- a/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterConfiguration.hpp
+++ b/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterConfiguration.hpp
@@ -79,6 +79,21 @@ struct EthercatMasterConfiguration{
    */
   bool logErrorCounters{false};
 
+  /*!
+   * Comparison operator
+  */
+  bool operator==(const EthercatMasterConfiguration& o) const{
+    return o.name == name && o.networkInterface == networkInterface && 
+                  o.timeStep == timeStep && o.pdoSizeCheck == pdoSizeCheck && 
+                  o.slaveDiscoverRetries == slaveDiscoverRetries && o.updateRateTooLowWarnThreshold == updateRateTooLowWarnThreshold &&
+                  o.rateCompensationCoefficient == rateCompensationCoefficient &&
+                  o.doBusDiagnosis == doBusDiagnosis &&
+                  o.logErrorCounters == logErrorCounters;
+  }
+
+  bool operator!=(const EthercatMasterConfiguration& o) const{
+    return !(o == *this);
+  }
 };
 
 } // namespace ecat_master

--- a/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
+++ b/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
@@ -17,10 +17,14 @@ namespace ecat_master {
 
                 if(ecat_masters_.find(config.networkInterface) == ecat_masters_.end())
                 {
+                    MELO_INFO_STREAM("Setting up new EthercatMaster on interface: " << config.networkInterface << " and updating it");
                     auto master = std::make_shared<EthercatMaster>();
                     master->loadEthercatMasterConfiguration(config);
+                    
+                    //Spin the master asynchronously
+                    spin_threads_.emplace(config.networkInterface, std::make_unique<std::thread>(std::bind(&EthercatMasterSingleton::spin,this, std::placeholders::_1), master));
                 }
-
+                
                 if(config != ecat_masters_[config.networkInterface]->getConfiguration()){
                     //Print warning or abort if the configuration does not match!
                     MELO_WARN_STREAM("Ethercat master configurations do not match for bus: " << config.networkInterface);
@@ -44,9 +48,27 @@ namespace ecat_master {
         EthercatMasterSingleton(){
 
         }
+        ~EthercatMasterSingleton() {
+            abort_ = true;
+
+            for(const auto& [interface, thread]: spin_threads_){
+                thread->join();
+            }
+            for(const auto &  [interfrace, master]: ecat_masters_){
+                master->preShutdown();
+                master->shutdown();
+            }
+        }
+        void spin(std::shared_ptr<EthercatMaster> master_){
+            while(!abort_){
+                master_->update(UpdateMode::StandaloneEnforceRate);
+            }
+        }
 
         std::map<std::string,std::shared_ptr<EthercatMaster>> ecat_masters_;
-        static std::recursive_mutex lock_;
+        std::map<std::string, std::unique_ptr<std::thread>> spin_threads_;
+        std::recursive_mutex lock_;
+        std::atomic_bool abort_ = false;
     };
 
 }

--- a/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
+++ b/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <ethercat_sdk_master/EthercatMaster.hpp>
+#include <map>
+
+namespace ecat_master {
+    /**
+     *  @brief Provides the only method how we can use the same ethercat bus in multiple ros2control hardware interfaces
+     * The idea is that we centrally manage the instances of the EthercatMasters and each hardware interface may attach its devices to it
+    */
+    class EthercatMasterSingleton {
+        public:
+            static EthercatMasterSingleton&  instance(); //Method has to be in cpp file in order to work properly
+
+            std::shared_ptr<EthercatMaster> get(const EthercatMasterConfiguration& config) {
+                std::lock_guard<std::recursive_mutex> guard(lock_);
+
+                if(ecat_masters_.find(config.networkInterface) == ecat_masters_.end())
+                {
+                    auto master = std::make_shared<EthercatMaster>();
+                    master->loadEthercatMasterConfiguration(config);
+                }
+
+                if(config != ecat_masters_[config.networkInterface]->getConfiguration()){
+                    //Print warning or abort if the configuration does not match!
+                }
+
+                return ecat_masters_[config.networkInterface];
+            }
+
+            bool hasMaster(const EthercatMasterConfiguration& config){
+                return ecat_masters_.find(config.networkInterface) != ecat_masters_.end();
+            }
+            bool hasMaster(const std::string& networkInterface) {
+                return ecat_masters_.find(networkInterface) != ecat_masters_.end();
+            }
+
+            std::shared_ptr<EthercatMaster> operator[] (const EthercatMasterConfiguration& config){
+                return get(config);
+            }
+        private:
+
+        EthercatMasterSingleton(){
+
+        }
+
+        std::map<std::string,std::shared_ptr<EthercatMaster>> ecat_masters_;
+        static std::recursive_mutex lock_;
+    };
+
+}

--- a/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
+++ b/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
@@ -60,6 +60,7 @@ namespace ecat_master {
             }
         }
         void spin(std::shared_ptr<EthercatMaster> master_){
+            master_->setRealtimePriority(); 
             while(!abort_){
                 master_->update(UpdateMode::StandaloneEnforceRate);
             }

--- a/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
+++ b/ethercat_sdk_master/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
@@ -23,6 +23,7 @@ namespace ecat_master {
 
                 if(config != ecat_masters_[config.networkInterface]->getConfiguration()){
                     //Print warning or abort if the configuration does not match!
+                    MELO_WARN_STREAM("Ethercat master configurations do not match for bus: " << config.networkInterface);
                 }
 
                 return ecat_masters_[config.networkInterface];

--- a/ethercat_sdk_master/src/ethercat_sdk_master/EthercatMasterSingleton.cpp
+++ b/ethercat_sdk_master/src/ethercat_sdk_master/EthercatMasterSingleton.cpp
@@ -1,0 +1,8 @@
+#include "ethercat_sdk_master/EthercatMasterSingleton.hpp"
+
+namespace ecat_master {
+    EthercatMasterSingleton&  EthercatMasterSingleton::instance() {
+        static EthercatMasterSingleton instance_;
+        return instance_;
+    }
+}


### PR DESCRIPTION
This PR adds some necessary additions needed in order to use this package with ros2control.

1. `-fPIC` is needed as compile flag
2. Adds EthercatMasterSingleton -> This is the only way I can think of at the moment how one could use the same ethercat master instance in multiple hardware interfaces 

__TODO:__

The EthercatMasterSingleton should also wrap the `update` of the handled EthercatMasters. otherwise multiple hardware interface will call `update` themselves in the `read/write` methods which leads to update being called too often. (Don't know if that would be an issue actually ?) 

EDIT: I solved this by having the singleton actually spin each master in a seperate thread. This should work as all the ethercat sdks are threadsafe as far as I know (or at least they should be)

@tfabi  and @janpreisig 